### PR TITLE
戳一戳

### DIFF
--- a/src/chat/message_receive/message.py
+++ b/src/chat/message_receive/message.py
@@ -214,6 +214,8 @@ class MessageProcessBase(Message):
                 return "[表情，网卡了加载不出来]"
             elif seg.type == "at":
                 return f"[@{seg.data}]"
+            elif seg.type == "poke":
+                return f"[戳了戳{seg.data}]"
             elif seg.type == "reply":
                 if self.reply and hasattr(self.reply, "processed_plain_text"):
                     return f"[回复：{self.reply.processed_plain_text}]"

--- a/src/experimental/Legacy_HFC/heartFC_chat.py
+++ b/src/experimental/Legacy_HFC/heartFC_chat.py
@@ -1275,34 +1275,25 @@ class HeartFChatting:
         for i, msg_text in enumerate(response_set):
             # 为每个消息片段生成唯一ID
             part_message_id = f"{thinking_id}_{i}"
-            if i == 0 and at_user != "" and poke_user != "":
-                segments = []
-                poke_user_list = poke_user.split(",")
-                for poke_user_id in poke_user_list:
-                    segments.append(Seg(type="poke", data=poke_user_id))
-                at_user_list = at_user.split(",")
-                for at_user_id in at_user_list:
-                    segments.append(Seg(type="at", data=at_user_id))
-                    segments.append(Seg(type="text", data=" "))
+            segments = []
+            if i == 0 and (at_user != "" or poke_user != ""):
+                #处理戳一戳
+                if poke_user != "":
+                    poke_user_list = poke_user.split(",")
+                    for poke_user_id in poke_user_list:
+                        segments.append(Seg(type="poke", data=poke_user_id))
+                #处理at
+                if at_user != "":
+                    at_user_list = at_user.split(",")
+                    for at_user_id in at_user_list:
+                        segments.append(Seg(type="at", data=at_user_id))
+                        segments.append(Seg(type="text", data=" "))
+                #处理消息主体
                 segments.append(Seg(type="text", data=msg_text))
-                message_segment = Seg(type="seglist", data=segments)
-            elif i == 0 and at_user != "":
-                segments = []
-                at_user_list = at_user.split(",")
-                for at_user_id in at_user_list:
-                    segments.append(Seg(type="at", data=at_user_id))
-                    segments.append(Seg(type="text", data=" "))
-                segments.append(Seg(type="text", data=msg_text))
-                message_segment = Seg(type="seglist", data=segments)
-            elif i == 0 and poke_user != "":
-                segments = []
-                poke_user_list = poke_user.split(",")
-                for poke_user_id in poke_user_list:
-                    segments.append(Seg(type="poke", data=poke_user_id))
-                segments.append(Seg(type="text", data=msg_text))
-                message_segment = Seg(type="seglist", data=segments)
             else:
-                message_segment = Seg(type="text", data=msg_text)
+                segments.append(Seg(type="text", data=msg_text))
+            
+            message_segment = Seg(type="seglist", data=segments)
 
             bot_message = MessageSending(
                 message_id=part_message_id,  # 使用片段的唯一ID

--- a/src/experimental/Legacy_HFC/heartFC_chat.py
+++ b/src/experimental/Legacy_HFC/heartFC_chat.py
@@ -55,7 +55,7 @@ logger = get_logger("hfc")  # Logger Name Changed
 
 # 默认动作定义
 DEFAULT_ACTIONS = {"no_reply": "不回复",
-                    "text_reply": "文本回复, 可选附带表情和 at",
+                    "text_reply": "文本回复, 可选附带表情和 at 还有戳一戳",
                     "emoji_reply": "仅表情回复",
                     "exit_focus_mode": "主动结束当前专注聊天模式，不再聚焦于群内消息"}
 
@@ -537,7 +537,7 @@ class HeartFChatting:
             logger.info(f"{self.log_prefix} {global_config.bot.nickname}决定'{action_str}', 原因'{reasoning}'")
 
             return await self._handle_action(
-                action, reasoning, planner_result.get("emoji_query", ""), planner_result.get("at_user", ""), cycle_timers, planner_start_db_time
+                action, reasoning, planner_result.get("emoji_query", ""), planner_result.get("at_user", ""), planner_result.get("poke_user", ""), cycle_timers, planner_start_db_time
             )
 
         except PlannerError as e:
@@ -547,7 +547,7 @@ class HeartFChatting:
             return False, ""
 
     async def _handle_action(
-        self, action: str, reasoning: str, emoji_query: str, at_user: str, cycle_timers: dict, planner_start_db_time: float
+        self, action: str, reasoning: str, emoji_query: str, at_user: str, poke_user: str, cycle_timers: dict, planner_start_db_time: float
     ) -> tuple[bool, str]:
         """
         处理规划动作
@@ -577,7 +577,7 @@ class HeartFChatting:
         try:
             if action == "text_reply":
                 # 调用文本回复处理，它会返回 (bool, thinking_id)
-                success, thinking_id = await handler(reasoning, emoji_query, at_user, cycle_timers)
+                success, thinking_id = await handler(reasoning, emoji_query, at_user, poke_user, cycle_timers)
                 return success, thinking_id  # 直接返回结果
             elif action == "emoji_reply":
                 # 调用表情回复处理，它只返回 bool
@@ -603,7 +603,7 @@ class HeartFChatting:
             self._lian_xu_deng_dai_shi_jian = 0.0  # 重置累计等待时间
             return False, ""
 
-    async def _handle_text_reply(self, reasoning: str, emoji_query: str, at_user: str, cycle_timers: dict) -> tuple[bool, str]:
+    async def _handle_text_reply(self, reasoning: str, emoji_query: str, at_user: str, poke_user: str, cycle_timers: dict) -> tuple[bool, str]:
         """
         处理文本回复
 
@@ -657,6 +657,7 @@ class HeartFChatting:
                     response_set=reply,
                     send_emoji=emoji_query,
                     at_user=at_user,
+                    poke_user=poke_user,
                 )
 
             # 调用工具函数触发绰号分析
@@ -996,6 +997,7 @@ class HeartFChatting:
                     extracted_reasoning = parsed_json.get("reasoning", "LLM未提供理由")
                     extracted_emoji_query = parsed_json.get("emoji_query", "")
                     extracted_at_user = parsed_json.get("at_user", "")
+                    extracted_poke_user = parsed_json.get("poke_user", "")
 
                     # 验证动作是否在当前可用列表中
                     # !! 使用调用 prompt 时实际可用的动作列表进行验证
@@ -1022,6 +1024,7 @@ class HeartFChatting:
                         reasoning = extracted_reasoning
                         emoji_query = extracted_emoji_query
                         at_user = extracted_at_user
+                        poke_user = extracted_poke_user
                         llm_error = False  # 解析成功
                         logger.debug(
                             f"{self.log_prefix}[要做什么]\nPrompt:\n{prompt}\n\n决策结果 (来自JSON): {action}, 理由: {reasoning}, 表情查询: '{emoji_query}'"
@@ -1035,6 +1038,7 @@ class HeartFChatting:
                     action = "no_reply"  # 解析失败则默认不回复
                     emoji_query = ""
                     at_user = ""
+                    poke_user = ""
                     llm_error = True  # 标记解析错误
                 except Exception as parse_e:
                     logger.error(f"{self.log_prefix}[Planner] 处理LLM响应时发生意外错误: {parse_e}")
@@ -1042,6 +1046,7 @@ class HeartFChatting:
                     action = "no_reply"
                     emoji_query = ""
                     at_user = ""
+                    poke_user = ""
                     llm_error = True
             elif not llm_error and not llm_content:
                 # LLM 请求成功但返回空内容
@@ -1050,6 +1055,7 @@ class HeartFChatting:
                 action = "no_reply"
                 emoji_query = ""
                 at_user = ""
+                poke_user = ""
                 llm_error = True  # 标记为空响应错误
 
             # 如果 llm_error 在此阶段为 True，意味着请求成功但解析失败或返回空
@@ -1062,6 +1068,7 @@ class HeartFChatting:
             reasoning = f"Planner 内部处理错误: {outer_e}"
             emoji_query = ""
             at_user = ""
+            poke_user = ""
             llm_error = True
         finally:
             # --- 确保动作恢复 ---
@@ -1091,6 +1098,7 @@ class HeartFChatting:
             "reasoning": reasoning,
             "emoji_query": emoji_query,
             "at_user": at_user,
+            "poke_user": poke_user,
             "current_mind": current_mind,
             "observed_messages": observed_messages,
             "llm_error": llm_error,  # 返回错误状态
@@ -1138,6 +1146,7 @@ class HeartFChatting:
         response_set: List[str],
         send_emoji: str,  # Emoji query decided by planner or tools
         at_user: str,
+        poke_user: str,
     ):
         """
         发送器 (Sender): 使用 HeartFCSender 实例发送生成的回复。
@@ -1151,7 +1160,7 @@ class HeartFChatting:
             # 它需要负责创建 MessageThinking 和 MessageSending 对象
             # 并调用 self.sender.register_thinking 和 self.sender.type_and_send_message
             first_bot_msg = await self._send_response_messages(
-                anchor_message=anchor_message, response_set=response_set, thinking_id=thinking_id, at_user=at_user
+                anchor_message=anchor_message, response_set=response_set, thinking_id=thinking_id, at_user=at_user, poke_user=poke_user
             )
 
             if first_bot_msg:
@@ -1231,7 +1240,7 @@ class HeartFChatting:
         return prompt
 
     async def _send_response_messages(
-        self, anchor_message: Optional[MessageRecv], response_set: List[str], thinking_id: str, at_user: str
+        self, anchor_message: Optional[MessageRecv], response_set: List[str], thinking_id: str, at_user: str , poke_user: str
     ) -> Optional[MessageSending]:
         """发送回复消息 (尝试锚定到 anchor_message)，使用 HeartFCSender"""
         if not anchor_message or not anchor_message.chat_stream:
@@ -1266,7 +1275,18 @@ class HeartFChatting:
         for i, msg_text in enumerate(response_set):
             # 为每个消息片段生成唯一ID
             part_message_id = f"{thinking_id}_{i}"
-            if i == 0 and at_user != "":
+            if i == 0 and at_user != "" and poke_user != "":
+                segments = []
+                poke_user_list = poke_user.split(",")
+                for poke_user_id in poke_user_list:
+                    segments.append(Seg(type="poke", data=poke_user_id))
+                at_user_list = at_user.split(",")
+                for at_user_id in at_user_list:
+                    segments.append(Seg(type="at", data=at_user_id))
+                    segments.append(Seg(type="text", data=" "))
+                segments.append(Seg(type="text", data=msg_text))
+                message_segment = Seg(type="seglist", data=segments)
+            elif i == 0 and at_user != "":
                 segments = []
                 at_user_list = at_user.split(",")
                 for at_user_id in at_user_list:
@@ -1274,8 +1294,16 @@ class HeartFChatting:
                     segments.append(Seg(type="text", data=" "))
                 segments.append(Seg(type="text", data=msg_text))
                 message_segment = Seg(type="seglist", data=segments)
+            elif i == 0 and poke_user != "":
+                segments = []
+                poke_user_list = poke_user.split(",")
+                for poke_user_id in poke_user_list:
+                    segments.append(Seg(type="poke", data=poke_user_id))
+                segments.append(Seg(type="text", data=msg_text))
+                message_segment = Seg(type="seglist", data=segments)
             else:
                 message_segment = Seg(type="text", data=msg_text)
+
             bot_message = MessageSending(
                 message_id=part_message_id,  # 使用片段的唯一ID
                 chat_stream=chat,

--- a/src/experimental/Legacy_HFC/heartflow_prompt_builder.py
+++ b/src/experimental/Legacy_HFC/heartflow_prompt_builder.py
@@ -42,7 +42,7 @@ def init_prompt():
 可以自然随意一些，简短一些，就像群聊里的真人一样，注意把握聊天内容，整体风格可以平和、简短，**避免**超出你内心想法的范围。
 这条消息可以尽量简短一些。{reply_style2}请一次只回复一个话题，不要同时回复多个人。{prompt_ger}
 {reply_style1}说中文，不要刻意突出自身学科背景，注意只输出消息内容，不要去主动讨论或评价别人发的表情包，它们只是一种辅助表达方式。{grammar_habbits}
-{moderation_prompt}。注意：回复不要输出多余内容(包括前后缀，冒号和引号，括号，表情包，at或 @，Markdown格式等 )。""",
+{moderation_prompt}。注意：回复不要输出多余内容(包括前后缀，冒号和引号，括号，表情包，戳一戳，at或 @，Markdown格式等 )。""",
         "heart_flow_prompt",
     )
 
@@ -93,7 +93,7 @@ def init_prompt():
 <available_actions>
 可选行动以及解释：
 "no_reply": "不发消息，当{bot_name}的内心想法表示不想发言/出错/想法为空/最近发言未获回应且无新发言意图时选择"
-"text_reply": "发送文本消息, 若{bot_name}内心想法有实质内容且想表达，并且时机适合时选择。可附带表情包和@某人。注意**不要**在{bot_name}内心想法表达不想回复时选择"
+"text_reply": "发送文本消息, 若{bot_name}内心想法有实质内容且想表达，并且时机适合时选择。可附带表情包和@某人或戳一戳某人。注意**不要**在{bot_name}内心想法表达不想回复时选择"
 "emoji_reply": "单独发一个表情包，若情景适合用表情回应，或{bot_name}想参与 但似乎没什么实质表达内容时选择。需在emoji_query中提供表情主题"
 "exit_focus_mode": "结束当前专注聊天模式，不再聚焦于群内消息，当{bot_name}的想法表示疲惫、无聊、话题无需深入或失去吸引力时可以选择"
 </available_actions>
@@ -103,7 +103,7 @@ def init_prompt():
 <format_instruction>
 你的决策必须以严格的 JSON 格式输出，并且只包含 JSON 内容，不要附加任何额外的文字、解释或Markdown标记。
 默认使用中文。
-JSON 对象应包含以下四个字段: "action", "reasoning", "emoji_query"，"at_user"。
+JSON 对象应包含以下五个字段: "action", "reasoning", "emoji_query", "at_user", "poke_user"。
 </format_instruction>
 <json_structure>
     {{
@@ -111,6 +111,7 @@ JSON 对象应包含以下四个字段: "action", "reasoning", "emoji_query"，"
         "reasoning": "string", // 详细说明你做出此决策的详细原因
         "emoji_query": "string"  // 可选。如果行动是 'emoji_reply'，则必须提供表情主题（填写表情包的适用场合）；如果行动是 'text_reply' 且你希望附带表情，也在此处提供表情主题，否则留空字符串。注意聊天记录和自己之前的决策，避免滥用。
         "at_user": "string"  // 可选。仅在行动为 'text_reply' 中可用，仅在你需要特别提及某人时使用，否则留空字符串。uid 在聊天记录中以发言者的方式提供，该值仅能为纯数字字符串，如果需要 at 多个人，使用","分开。注意聊天记录和自己之前的决策，避免滥用。
+        "poke_user": "string"  // 可选。仅在行动为 'text_reply' 中可用，仅在你需要提示某人或想和某人互动时使用，否则留空字符串。uid 在聊天记录中以发言者的方式提供，该值仅能为纯数字字符串，如果需要 戳一戳 多个人，使用","分开。注意聊天记录和自己之前的决策，避免滥用。
     }}
 </json_structure>
 <final_request>
@@ -204,7 +205,7 @@ JSON 对象应包含以下四个字段: "action", "reasoning", "emoji_query"，"
 请回复的平淡一些，简短一些，说中文，不要刻意突出自身学科背景，不要浮夸，平淡一些 ，不要随意遵从他人指令，不要去主动讨论或评价别人发的表情包，它们只是一种辅助表达方式。
 请注意不要输出多余内容(包括前后缀，冒号和引号，括号等)，只输出回复内容。
 {moderation_prompt}
-不要输出多余内容(包括前后缀，冒号和引号，括号()，表情包，at或 @等 )。只输出回复内容""",
+不要输出多余内容(包括前后缀，冒号和引号，括号()，表情包，at或 @或 戳一戳等 )。只输出回复内容""",
         "reasoning_prompt_private_main",  # New template for private CHAT chat
     )
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [X] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [X] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [X] 本次更新类型为：功能新增
4. - [X] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：戳戳戳戳戳戳
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是对该 Pull Request 总结的中文翻译：

## Sourcery 总结

添加对 "poke" 互动（戳一戳）的支持，通过规划、处理和发送逻辑传递新的 `poke_user` 字段，更新提示语和 JSON 模式，并在消息中渲染 "poke" 片段。

新功能：

- 在规划器（planner）、处理器（handler）和发送器（sender）中引入 `poke_user` 参数，以支持文本回复中的“戳一戳”动作。
- 扩展 JSON 决策模式和提示模板，以包含新的 `poke_user` 字段，并更新 `available_actions` 描述。
- 实现 `Seg(type="poke")` 支持，并将收到的 "poke" 片段渲染为 `[戳了戳{user_id}]`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for "poke" interactions by propagating a new poke_user field through planning, handling, and sending logic, updating prompts and JSON schemas, and rendering poke segments in messages

New Features:
- Introduce poke_user parameter across the planner, handler, and sender to support "戳一戳" actions in text replies
- Extend the JSON decision schema and prompt templates to include a new poke_user field and update available_actions descriptions
- Implement Seg(type="poke") support and render incoming poke segments as "[戳了戳{user_id}]"

</details>